### PR TITLE
Coerce all data to String

### DIFF
--- a/gsheets/gsheets.py
+++ b/gsheets/gsheets.py
@@ -267,7 +267,7 @@ class SheetPushInterface(BaseSheetInterface):
         row_data = []
         for field, ix in sorted_field_indexes:
             logger.debug(f'writing data in field {field} to col ix {ix}')
-            row_data.append(data[field])
+            row_data.append(str(data[field]))
 
         # get the row to update if it exists, otherwise we will add a new row
         existing_row_ix = self.existing_row(**data)


### PR DESCRIPTION
Forces the row data to be of type string. This means that a model with an object related to it, can be saved to Google Sheets.

The def __str__ function can control what is saved.